### PR TITLE
Added coronavirus-news-agents.json to the Open Source Apps category.

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -23,11 +23,6 @@
           "title": "MG-ng/Virus-Ticker-Widget",
           "url": "https://www.github.com/MG-ng/Virus-Ticker-Widget",
           "description": "Android App to display a homescreen widget and useful websites in fullscreen."
-        },
-        {
-          "title": "virtadpt/exocortex-agents/coronavirus-news-agents.json",
-          "url": "https://github.com/virtadpt/exocortex-agents/blob/master/coronavirus-news-agents.json",
-          "description": "A Huginn (https://github.com/huginn/huginn) agent network that monitors global news sources and public health agencies for covid-19 news.  Emails periodic updates to the instance's default e-mail address.  Not comprehensive."
         }
       ]
     },

--- a/data/applications.json
+++ b/data/applications.json
@@ -23,6 +23,11 @@
           "title": "MG-ng/Virus-Ticker-Widget",
           "url": "https://www.github.com/MG-ng/Virus-Ticker-Widget",
           "description": "Android App to display a homescreen widget and useful websites in fullscreen."
+        },
+        {
+          "title": "virtadpt/exocortex-agents/coronavirus-news-agents.json",
+          "url": "https://github.com/virtadpt/exocortex-agents/blob/master/coronavirus-news-agents.json",
+          "description": "A Huginn (https://github.com/huginn/huginn) agent network that monitors global news sources and public health agencies for covid-19 news.  Emails periodic updates to the instance's default e-mail address.  Not comprehensive."
         }
       ]
     },

--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -30,7 +30,8 @@
         "joaotinti75/Coronavirus",
         "alext234/coronavirus-stats",
         "HopkinsIDD/ncov_incubation",
-        "BlankerL/DXY-COVID-19-Data"
+        "BlankerL/DXY-COVID-19-Data",
+        "virtadpt/exocortex-agents"
       ]
     },
     {


### PR DESCRIPTION
This is a Huginn (https://github.com/huginn/huginn/) agent network which monitors some news and global health agencies' public feeds for covid-19 stats.  Right now it's configured to send periodic news updates to the Huginn instance's default email address but it's easily hackable.