### PR TITLE
Added models category, renamed statistics and data category

### DIFF
--- a/data/contents.json
+++ b/data/contents.json
@@ -15,8 +15,12 @@
           "anchor": "api"
         },
         {
-          "title": "Statistics and Data",
-          "anchor": "statistics-and-data"
+          "title": "Statistics and Datasets",
+          "anchor": "statistics-and-datasets"
+        },
+        {
+          "title": "Models",
+          "anchor": "models"
         },
         {
           "title": "Learning",

--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -15,7 +15,7 @@
       ]
     },
     {
-      "category": "Statistics and Data",
+      "category": "Statistics and Datasets",
       "repositories": [
         "CSSEGISandData/COVID-19",
         "globalcitizen/2019-wuhan-coronavirus-dat",
@@ -32,14 +32,19 @@
         "tmacdou4/2019-nCov",
         "joaotinti75/Coronavirus",
         "alext234/coronavirus-stats",
-        "HopkinsIDD/ncov_incubation",
         "BlankerL/DXY-COVID-19-Data",
         "virtadpt/exocortex-agents",
-        "coronafighter/coronaSEIR",
         "pcm-dpc/COVID-19",
         "pomber/covid19",
         "globalcitizen/2019-wuhan-coronavirus-data",
         "arnoudbuzing/wolfram-coronavirus"
+      ]
+    },
+    {
+      "category": "Models",
+      "repositories": [
+        "HopkinsIDD/ncov_incubation",
+        "coronafighter/coronaSEIR"
       ]
     },
     {


### PR DESCRIPTION
There is a growing number of models that are published by researchers around the world, including two published under "statistics and data" category. I propose splitting the category into two, to make it easier to navitage for researchers: (1) statistics and datasets and (2) models. I have several model links to add here after the new category change is approved.