### PR TITLE
Add Corona-tracker

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -158,6 +158,11 @@
           "title": "Work From Home Gigs",
           "url": "https://bit.ly/WFH143",
           "description": "A weekly updated list of work from home jobs during the COVID-19 Pandemic"
+        },
+        {
+          "title": "Corona-tracker",
+          "url": "https://corona-tracker-2020.netlify.com/",
+          "description": "Web app to track Coronavirus with primary focus on India"
         }
       ]
     },


### PR DESCRIPTION
Corona-tracker is a Web app to track Coronavirus with a primary focus on India.