### PR TITLE
Include WHO WhatsApp Bot

### DIFF
--- a/data/social.json
+++ b/data/social.json
@@ -98,6 +98,11 @@
           "title": "latest information about the COVID-19",
           "url": "https://go.gov.sg/whatsapp",
           "description": "Gov.sg WhatsApp Subscription"
+        },
+        {
+          "title": "WHO Health Alert",
+          "url": "http://bit.ly/who-covid19-whatsapp",
+          "description": "WHO WhatsApp Subscription for COVID-19 related information"
         }
       ]
     },


### PR DESCRIPTION
Who launched a WhatsApp bot to deliver COVID-19 related information to billion of users.

Source: https://www.who.int/news-room/feature-stories/detail/who-health-alert-brings-covid-19-facts-to-billions-via-whatsapp