### PR TITLE
Adding Denver Health epidemiology models

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -58,7 +58,8 @@
         "pennsignals/chime",
         "daveselinger/covid-19-hackathon",
         "midas-network/COVID-19",
-        "neherlab/covid19_scenarios"
+        "neherlab/covid19_scenarios",
+        "Mythobeast/epidemicmodels"
       ]
     },
     {


### PR DESCRIPTION
Python based models that shift from standard differential equations to a time-series Markov model.