### PR TITLE
Add covid19-load-qgis to "Packages and Scripts"

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -112,7 +112,8 @@
         "koushikkothagal/coronavirus-tracker",
         "eebrown/data2019nCoV",
         "pdtyreus/coronavirus-ds",
-        "eebrown/data2019nCoV"
+        "eebrown/data2019nCoV",
+        "benhur07b/covid19-load-qgis"
       ]
     },
     {


### PR DESCRIPTION
benhur07b/covid19-load-qgis is a Python script for loading data from the JHU CSSE repo as point vector files in QGIS.