### PR TITLE
Add Android Apps: COVID-19 Daily Report Viewer

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -107,7 +107,8 @@
         "yohix/corona",
         "duarteocarmo/coronabar",
         "cakebatterandsprinkles/whereiscovid",
-        "YogaSakti/CoronaNotifier"
+        "YogaSakti/CoronaNotifier",
+        "bluebillxp/android-covid19-reportviewer"
       ]
     },
     {


### PR DESCRIPTION
Repo: https://github.com/bluebillxp/android-covid19-reportviewer
The COVID-19 daily report viewer on Android presents info from CSSE@JHU open-sourced data repo.