### PR TITLE
Adding COVID-19 Tracker for Pakistan Web App

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -1,6 +1,6 @@
 {
   "title": "Applications",
-  "list" :  [
+  "list": [
     {
       "category": "Web Apps",
       "list": [
@@ -243,6 +243,11 @@
           "title": "worldometers.info",
           "url": "https://www.worldometers.info/coronavirus",
           "description": "Coronavirus Live Update Stats."
+        },
+        {
+          "title": "COVID-19 Tracker For Pakistan",
+          "url": "https://pakistan-covid19.herokuapp.com",
+          "description": "COVID 19 Tracker For Pakistan"
         }
       ]
     },


### PR DESCRIPTION
This is COVID-19 tracking web app for Pakistan that uses a WorldoMeters based API and JHU Data Repository to show all COVID-19 statistics related to Pakistan.