### PR TITLE
Added cinemast/covid19-at

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -21,7 +21,8 @@
         "marlon360/rki-covid-api",
         "lkd70/coronapi",
         "ChrisMichaelPerezSantiago/covid19",
-        "AlaeddineMessadi/COVID-19-REPORT-API"
+        "AlaeddineMessadi/COVID-19-REPORT-API",
+        "cinemast/covid19-at"
       ]
     },
     {


### PR DESCRIPTION
covid19-at is an open-source project scrapping COVID-19 related data from government official sites in Austria.