### PR TITLE
Adding COVID-19 Data Tracker for Pakistan WebApp

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -253,6 +253,11 @@
           "title": "Help with COVID",
           "url": "https://helpwithcovid.com",
           "description": "COVID-19 projects looking for volunteers"
+        },
+        {
+          "title": "COVID19 statistics Pakistan",
+          "url": "https://covid-19-pk.herokuapp.com",
+          "description": "COVID-19 Data Tracker For Pakistan"
         }
       ]
     },


### PR DESCRIPTION
A COVID-19 tracking web app for Pakistan that scrapes data from WorldoMeters and from Pakistan Government websites to show all COVID-19 statistics related to Pakistan.