### PR TITLE
Update name of coviddata repo

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -54,7 +54,7 @@
         "kalisio/covid-19",
         "OssamaRafique/Corona-Statistics-And-Tracker-Dashboard-Angular-9",
         "rfearing/temp-covid-resources",
-        "coviddata/covid-api",
+        "coviddata/coviddata",
         "datasets/covid-19",
         "PhantasWeng/coronavirus-daily-dashboard"
       ]


### PR DESCRIPTION
This repo has been renamed from `coviddata/covid-api` to `coviddata/coviddata`