### PR TITLE
Add ECDC (the European CDC) to the list of current status

### DIFF
--- a/data/current-status.json
+++ b/data/current-status.json
@@ -10,6 +10,11 @@
       "title": "CDC",
       "url": "https://www.cdc.gov/coronavirus/2019-ncov/about/index.html",
       "description": "Center for Disease control."
+    },
+    {
+      "title": "ECDC",
+      "url": "https://www.ecdc.europa.eu/en/novel-coronavirus-china",
+      "description": " European Centre for Disease Prevention and Control"
     }
   ]
 }


### PR DESCRIPTION
The European CDC (the counterpart of the US CDC) also publishes reports and a dataset about the current COVID status worldwid.

(Ignore the `-china` in the URL, as they probably didn't change the URL slug.  The dashboard is about the current status.)