### PR TITLE
Add derived dataset based on JHU, NY Times and ECDC

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -56,7 +56,8 @@
         "rfearing/temp-covid-resources",
         "coviddata/covid-api",
         "datasets/covid-19",
-        "PhantasWeng/coronavirus-daily-dashboard"
+        "PhantasWeng/coronavirus-daily-dashboard",
+        "cipriancraciun/covid19-datasets"
       ]
     },
     {


### PR DESCRIPTION
The suggested dataset (https://github.com/cipriancraciun/covid19-datasets) is a project made by me that processes the JHU, NY Times and ECDC datasets into a unitary format, and augments them by computing some useful metrics (such as days since first case, first 10, 100, etc.;  relative values to the population).