### PR TITLE
Add Italy's official dataset

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -56,7 +56,8 @@
         "rfearing/temp-covid-resources",
         "coviddata/covid-api",
         "datasets/covid-19",
-        "PhantasWeng/coronavirus-daily-dashboard"
+        "PhantasWeng/coronavirus-daily-dashboard",
+        "pcm-dpc/COVID-19"
       ]
     },
     {


### PR DESCRIPTION
The pointed repository (https://github.com/pcm-dpc/COVID-19) is curated by the *Dipartimento della Protezione Civile* (i.e. civil protection department) thus it should provide trustworthy and in-depth data for Italy.