### PR TITLE
Remove “|” from title

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -300,7 +300,7 @@
           "description": "Tracking the cost of COVID-19 across China, Europe and the United States in human lives and economies."
         },
         {
-          "title": "Flattening the curve | COVID-19 🦠",
+          "title": "Flattening the curve - COVID-19 🦠",
           "url": "https://flattening-the-curve.commutatus.com",
           "description": "A simple dashboard to track flattening of the curve by plotting the no.of active COVID-19 / Coronavirus cases over a period of time by countries."
         },


### PR DESCRIPTION
Replace “|” with “-“ in the title due to table formatting issue.