### PR TITLE
Add support for listing subdirectories of monorepos in open source projects, and add reach4help map

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -91,7 +91,12 @@
         "konradkalemba/korona.ws",
         "ankitchouhan1020/corona",
         "opencovid19-fr/dashboard",
-        "bustbyte/coronastatus"
+        "bustbyte/coronastatus",
+        {
+          "repo": "reach4help/reach4help",
+          "subdir": "map",
+          "description": "A map of COVID-19 mutual-aid projects and organizations around the world"
+        }
       ]
     },
     {


### PR DESCRIPTION
Some relevant projects are sub-projects of larger projects, and are accessible via sub-directories of monorepos, rather than the root of a particular repository.

In these instances, we want to be able to link directly to those subdirectories, and (optionally) provide an override for the description, rather than taking the info from the monorepo.

One such relevant project is the mutual-aid map for reach4help, that is accessible here: https://map.reach4help.org/ whose code is here: https://github.com/reach4help/reach4help/tree/master/map and is part of the larger reach4help project.