### PR TITLE
open source bluetoth based covid tracing app git repo added

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -308,6 +308,11 @@
           "title": "covintern.com",
           "url": "https://covintern.com/jobs",
           "description": "Internship cancellation tracker and remote internship aggregator for affected students."
+        },
+        {
+          "title": "Bluetooth corona tracer",
+          "url": "https://github.com/helloworldkr/Bluetooth-ble-beamer-and-scanner-for-tracing-corona-virus-infected-individual",
+          "description": "This is an open source skeleton app similar to Singapore 'Trace Together' app for Covid 19 tracing using ble beacons"
         }
       ]
     },


### PR DESCRIPTION
This is an open-source Bluetooth BLE beacon-based human contact tracing app.  It registers the nearby devices around people and when someone is tested positive for covid-19 then those who were around the infected person are alerted. The implementation is similar to Singapore Gov Trace Together app and there are many institutions try to build a similar app where this will help give a good headstart and save time. 

Merge issue:
As requested I have added info only in application.json but I don't see that getting reflected in readme.md. Do I need to do anything else
