### PR TITLE
open source bluetoth based covid tracing app git repo added

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -308,7 +308,8 @@
           "title": "covintern.com",
           "url": "https://covintern.com/jobs",
           "description": "Internship cancellation tracker and remote internship aggregator for affected students."
-        },{
+        },
+        {
           "title": "COVID-2019.es",
           "url": "http://covid-2019.es",
           "description": "Spain coronavirus tracker. Offers daily JSON data parsed from official government sources."

--- a/data/applications.json
+++ b/data/applications.json
@@ -308,15 +308,15 @@
           "title": "covintern.com",
           "url": "https://covintern.com/jobs",
           "description": "Internship cancellation tracker and remote internship aggregator for affected students."
+        },{
+          "title": "COVID-2019.es",
+          "url": "http://covid-2019.es",
+          "description": "Spain coronavirus tracker. Offers daily JSON data parsed from official government sources."
         },
         {
           "title": "Bluetooth corona tracer",
           "url": "https://github.com/helloworldkr/Bluetooth-ble-beamer-and-scanner-for-tracing-corona-virus-infected-individual",
           "description": "This is an open source skeleton app similar to Singapore 'Trace Together' app for Covid 19 tracing using ble beacons"
-        },{
-          "title": "COVID-2019.es",
-          "url": "http://covid-2019.es",
-          "description": "Spain coronavirus tracker. Offers daily JSON data parsed from official government sources."
         }
       ]
     },

--- a/data/applications.json
+++ b/data/applications.json
@@ -308,6 +308,11 @@
           "title": "covintern.com",
           "url": "https://covintern.com/jobs",
           "description": "Internship cancellation tracker and remote internship aggregator for affected students."
+        },
+        {
+          "title": "Bluetooth corona tracer",
+          "url": "https://github.com/helloworldkr/Bluetooth-ble-beamer-and-scanner-for-tracing-corona-virus-infected-individual",
+          "description": "This is an open source skeleton app similar to Singapore 'Trace Together' app for Covid 19 tracing using ble beacons"
         }
       ]
     },

--- a/data/applications.json
+++ b/data/applications.json
@@ -313,11 +313,6 @@
           "title": "COVID-2019.es",
           "url": "http://covid-2019.es",
           "description": "Spain coronavirus tracker. Offers daily JSON data parsed from official government sources."
-        },
-        {
-          "title": "Bluetooth corona tracer",
-          "url": "https://github.com/helloworldkr/Bluetooth-ble-beamer-and-scanner-for-tracing-corona-virus-infected-individual",
-          "description": "This is an open source skeleton app similar to Singapore 'Trace Together' app for Covid 19 tracing using ble beacons"
         }
       ]
     },

--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -126,7 +126,8 @@
         "mayukh18/covidexplore",
         "nutboltu/australia-covid19",
         "Spiderpig86/sea-to-go",
-        "nploi/corona_tracker"
+        "nploi/corona_tracker",
+        "helloworldkr/Bluetooth-ble-beamer-and-scanner-for-tracing-corona-virus-infected-individual"
       ]
     },
     {


### PR DESCRIPTION
This is an open-source Bluetooth BLE beacon-based human contact tracing app. It registers the nearby devices around people and when someone is tested positive for covid-19 then those who were around the infected person are alerted. The implementation is similar to Singapore Gov Trace Together app and there are many institutions try to build a similar app where this will help give a good headstart and save time.

Merge issue:
As requested I have added info only in application.json but I don't see that getting reflected in readme.md. Do I need to do anything else

**Changed from previous merge request**:
I observed that the entry made by me was not the end of the list
So I have made the changes.
I could not find any other mistake where I am differing from the guideline.
If I am still making any mistake, it will be helpful if you pinpoint the violation 