### PR TITLE
Add datasets of brazilian project Colaboradados

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -60,7 +60,7 @@
         "nytimes/covid-19-data",
         "cipriancraciun/covid19-datasets",
         "pcm-dpc/COVID-19",
-        "colaboradados/colaboradados.github.io/blob/dev/_posts/2020-03-19-coronavirus.md"
+        "colaboradados/colaboradados.github.io"
       ]
     },
     {

--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -59,7 +59,8 @@
         "PhantasWeng/coronavirus-daily-dashboard",
         "nytimes/covid-19-data",
         "cipriancraciun/covid19-datasets",
-        "pcm-dpc/COVID-19"
+        "pcm-dpc/COVID-19",
+        "colaboradados/colaboradados.github.io/blob/dev/_posts/2020-03-19-coronavirus.md"
       ]
     },
     {


### PR DESCRIPTION
The Colaboradados project gather government transparency portals in Brazil. In this PR is the repository with the file of Coronavirus datasets of Brazil.