### PR TITLE
Add covid19-japan-web-api to API category

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -24,7 +24,8 @@
         "AlaeddineMessadi/COVID-19-REPORT-API",
         "cinemast/covid19-at",
         "elias-garcia/covid-19-spain",
-        "PotentialWeb/CoronaTab"
+        "PotentialWeb/CoronaTab",
+        "ryo-ma/covid19-japan-web-api"
       ]
     },
     {


### PR DESCRIPTION
The API that summarizes Japanese coronavirus information.
Please add to the API category.