### PR TITLE
Add  ghaake/stay-home-snackbar to open-source-projects

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -174,7 +174,7 @@
       ]
     },
     {
-      "category: "Plugin",
+      "category: "Plugins",
       "repositories" : [
         "ghaake/stay-home-snackbar"
       ]

--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -172,6 +172,12 @@
       "repositories": [
         "SolaceLabs/jhu-covid19-stream-processors"
       ]
+    },
+    {
+      "category: "Plugin",
+      "repositories" : [
+        "ghaake/stay-home-snackbar"
+      ]
     }
   ]
 }


### PR DESCRIPTION
I have not found a corresponding category and therefore created a new one.