### PR TITLE
Add GAMA CoVid19 models repository

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -77,7 +77,8 @@
         "Mythobeast/epidemicmodels",
         "institutefordiseasemodeling/covasim",
         "p-j-r/covid-19",
-        "funcional-health-analytics/covid19-analytics"
+        "funcional-health-analytics/covid19-analytics",
+        "WARMTeam/CoVid19"
       ]
     },
     {


### PR DESCRIPTION
Hi,

I want to add the repository on which we are developing a collection of GAMA (http://gama-platform.org) models on various aspects of the COVID-19 pandemics. For now, it's mainly based in Vietnam, but the goal is to provide an abstract model which will work with any set of data around the world.

Thanks, stay safe and stay at home ! :wink: 