### PR TITLE
Add covidaid.ch

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -343,6 +343,11 @@
           "title": "stats-coronavirus.com",
           "url": "https://stats-coronavirus.com",
           "description": "STATS-CORONAVIRUS.com is an open source project that aims to collect data about the Novel Cornavirus. It acts as a portal for the public to keep track of the latest analytics and news development about the COVID-19"
+        },
+        {
+          "title": "covidaid.ch",
+          "url": "https://covidaid.ch",
+          "description": "covidaid.ch is an open source website that aims to help swiss companies and entrepreneurs to calculate the amount of state aid they can get during the COVID 19 crisis."
         }
       ]
     },


### PR DESCRIPTION
covidaid.ch is an open-source tool (web app) to help companies and entrepreneurs to calculate the amount of (financial) state aid they can get during the COVID 19 crisis.

The repo is here : https://github.com/Natsierro/COVID-19-Financial-Aid-Calculator (I only put a link to the website, which is IMO enough as the website's footer contains a link to the repo).