### PR TITLE
Add covid-19-app

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -152,7 +152,8 @@
         "onl1ner/CovidKazakhstan",
         "dabigjoe6/react-native-covid19",
         "varundeva/CoronaTracker",
-        "destructo570/CovidTracker"
+        "destructo570/CovidTracker",
+        "bluesquare-io/covid-19-app"
       ]
     },
     {


### PR DESCRIPTION
covid-19-app is an open-source tool (mobile app) developed as a starting point for volunteers and organizations willing to provide a tool or a companion to a group of people (even countrywide!) during the COVID-19 crisis.

The repo is here : https://github.com/bluesquare-io/covid-19-app