### PR TITLE
Colombia Covid 19 Pipeline

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -75,7 +75,8 @@
         "cjvanlissa/COVID19_metadata",
         "AlaeddineMessadi/COVID-19-REPORT-DASHBOARD",
         "hmpandey/CoronaQs",
-        "github/covid19-dashboard"
+        "github/covid19-dashboard",
+        "sebaxtian/colombia_covid_19_pipe"
       ]
     },
     {


### PR DESCRIPTION
Pipeline to get dataset from Instituto Nacional de Salud daily report Coronavirus Covid 19 from Colombia.