### PR TITLE
Add CovidRadar telegram bot

### DIFF
--- a/data/social.json
+++ b/data/social.json
@@ -118,6 +118,11 @@
           "title": "@coronapandemicbot",
           "url": "https://t.me/coronapandemicbot",
           "description": "A bot that gives you up-to-date statistics on the worldwide spread of the COVID-19 disease."
+        },
+        {
+          "title": "@CovidRadar",
+          "url": "https://t.me/CovidRradarBot",
+          "description": "Coronavirus Cases: statistics, charts and trends"
         }
       ]
     },


### PR DESCRIPTION
### [CovidRadar](https://t.me/CovidRradarBot) telegram bot

Coronavirus Cases: statistics, charts and trends. It's [open sourced](https://github.com/Covid-Lab/covid_radar) also.

![photo_2020-04-08 20 10 05](https://user-images.githubusercontent.com/2356771/78816411-5d196c00-79da-11ea-9b6f-f03ca26bf835.jpeg)
