### PR TITLE
Adding FOSS Responders

### DIFF
--- a/data/applications.json
+++ b/data/applications.json
@@ -408,6 +408,11 @@
           "title": "COVID-19 By Country",
           "url": "https://cityxdev.github.io/covid19ByCountry",
           "description": "This is a comparison of the COVID-19 pandemic by country, weighted by population. Every data series begins on the day that the corresponding country reached the 100th confirmed case."
+        },
+        {
+          "title": "FOSS Responders",
+          "url": "https://fossresponders.com",
+          "description": "A website to help aid open source developers and companies which have suffered as the result of event cancellations or other impacts from COVID-19"
         }
       ]
     },


### PR DESCRIPTION
A website to help aid open source developers and companies which have suffered as the result of event cancellations or other impacts from COVID-19. This was mentioned in #272.