### PR TITLE
docs(contribute): Move data note to list

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,10 +1,8 @@
-
 # Contribution Guidelines
-
-**If you want to contribute, note that you should only update `data/*.json`.**
 
 Ensure your pull request adheres to the following guidelines:
 
+- **If you want to contribute, note that you should only update `data/*.json`.**
 - Place your item at end of the related list.
 - Search previous suggestions before making a new one, as yours may be a duplicate.
 - Make an individual pull request for each suggestion.


### PR DESCRIPTION
I assiduously checked the list, twice, to make sure I was following it. However, I missed the bold note. I think that adding it to the list, explicitely, but keeping the bold will ensure that that this will not happen to other potential contributors. Something about being the same color and weight as the header made it easy for my eyes to glide over.