### PR TITLE
add Brasil.io dataset with daily, city level data on Covid-19 for Brazil

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -81,7 +81,8 @@
         "github/covid19-dashboard",
         "sebaxtian/colombia_covid_19_pipe",
         "UniversalDataTool/coronavirus-mask-image-dataset",
-        "cityxdev/covid19ByCountry"
+        "cityxdev/covid19ByCountry",
+        "turicas/covid19-br"
       ]
     },
     {


### PR DESCRIPTION
Please check the following items before submitting the pull request:

- [x] **I only updated `data/*.json`.**
- [x] I placed my item at the end of the related list.
- [x] My suggestion is not a duplicate.
- [x] This pull request contains one item.
- [x] My item descriptions are short and simple, but descriptive.
- [x] I checked my item spelling and grammar.

Data scraped from official State Health Secretariat reports, made available by volunteers on the Brasil.io collaborative platform as CSV downloads and an API. Updated daily and has city-level data.