### PR TITLE
Fixed incorrect app name for Togo

### DIFF
--- a/data/open-source-projects.json
+++ b/data/open-source-projects.json
@@ -161,7 +161,7 @@
         "nthopinion/covid19",
         "mayukh18/covidexplore",
         "nutboltu/australia-covid19",
-        "Spiderpig86/sea-to-go",
+        "Spiderpig86/to-go",
         "nploi/corona_tracker",
         "helloworldkr/Bluetooth-ble-beamer-and-scanner-for-tracing-corona-virus-infected-individual",
         "boogheta/coronavirus-countries",


### PR DESCRIPTION
Minor update to update the app name from SeaToGo to Togo.

Please check the following items before submitting the pull request:

- [x] **I only updated `data/*.json`.**
- [x] I placed my item at the end of the related list.
- [x] My suggestion is not a duplicate.
- [x] This pull request contains one item.
- [x] My item descriptions are short and simple, but descriptive.
- [x] I checked my item spelling and grammar.
